### PR TITLE
fix: YAML syntax error in deploy-docs workflow heredoc (#55)

* Initial plan

* fix: replace heredoc with grouped echo commands to fix YAML syntax error in deploy-docs.yml

Agent-Logs-Url: https://github.com/pietroserrano/forma/sessions/9729cbfc-a235-43e1-8294-4b040d9f8f53

Co-authored-by: pietroserrano <33091150+pietroserrano@users.noreply.github.com>

---------

Co-authored-by: copilot-swe-agent[bot] <198982749+Copilot@users.noreply.github.com>
Co-authored-by: pietroserrano <33091150+pietroserrano@users.noreply.github.com>

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -94,20 +94,20 @@ jobs:
           python3 .github/scripts/update_versions.py "$VERSIONS_FILE" "$VERSION"
 
           # Root redirect — sends bare /forma/ visitors to the latest stable docs
-          cat > /tmp/gh-pages/index.html << 'HTMLEOF'
-<!DOCTYPE html>
-<html>
-  <head>
-    <meta charset="utf-8">
-    <meta http-equiv="refresh" content="0; url=./latest/">
-    <link rel="canonical" href="./latest/">
-    <title>Forma Docs</title>
-  </head>
-  <body>
-    Redirecting to <a href="./latest/">latest documentation</a>...
-  </body>
-</html>
-HTMLEOF
+          {
+            echo '<!DOCTYPE html>'
+            echo '<html>'
+            echo '  <head>'
+            echo '    <meta charset="utf-8">'
+            echo '    <meta http-equiv="refresh" content="0; url=./latest/">'
+            echo '    <link rel="canonical" href="./latest/">'
+            echo '    <title>Forma Docs</title>'
+            echo '  </head>'
+            echo '  <body>'
+            echo '    Redirecting to <a href="./latest/">latest documentation</a>...'
+            echo '  </body>'
+            echo '</html>'
+          } > /tmp/gh-pages/index.html
 
       - name: Save to gh-pages branch (version storage)
         env:

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -12,15 +12,20 @@ on:
 
 permissions:
   contents: write
+  pages: write
+  id-token: write
 
-# Serialize all deployments to prevent race conditions on the gh-pages branch
+# Serialize all deployments to prevent race conditions
 concurrency:
-  group: deploy-gh-pages
+  group: pages
   cancel-in-progress: false
 
 jobs:
   build-and-deploy:
     runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -74,6 +79,9 @@ jobs:
             echo "Starting fresh gh-pages deployment"
           fi
 
+          # Ensure .nojekyll exists to prevent Jekyll from interfering with the static site
+          touch /tmp/gh-pages/.nojekyll
+
           # Copy built docs into version subdirectory
           mkdir -p /tmp/gh-pages/$VERSION
           rsync -a --delete docs/.vitepress/dist/ /tmp/gh-pages/$VERSION/
@@ -87,21 +95,21 @@ jobs:
 
           # Root redirect — sends bare /forma/ visitors to the latest stable docs
           cat > /tmp/gh-pages/index.html << 'HTMLEOF'
-          <!DOCTYPE html>
-          <html>
-            <head>
-              <meta charset="utf-8">
-              <meta http-equiv="refresh" content="0; url=./latest/">
-              <link rel="canonical" href="./latest/">
-              <title>Forma Docs</title>
-            </head>
-            <body>
-              Redirecting to <a href="./latest/">latest documentation</a>...
-            </body>
-          </html>
-          HTMLEOF
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=./latest/">
+    <link rel="canonical" href="./latest/">
+    <title>Forma Docs</title>
+  </head>
+  <body>
+    Redirecting to <a href="./latest/">latest documentation</a>...
+  </body>
+</html>
+HTMLEOF
 
-      - name: Deploy to GitHub Pages
+      - name: Save to gh-pages branch (version storage)
         env:
           VERSION: ${{ steps.version.outputs.version }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -112,11 +120,20 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add -A
           if git diff --cached --quiet; then
-            echo "No changes to deploy for $VERSION"
+            echo "No changes to save for $VERSION"
           else
-            git commit -m "docs: deploy $VERSION [skip ci]"
+            git commit -m "docs: save $VERSION [skip ci]"
             git push --force \
               "https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" \
               HEAD:gh-pages
-            echo "Successfully deployed $VERSION"
+            echo "Saved $VERSION to gh-pages branch"
           fi
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: /tmp/gh-pages
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/docs/.vitepress/theme/CustomLayout.vue
+++ b/docs/.vitepress/theme/CustomLayout.vue
@@ -10,6 +10,9 @@ const { Layout } = DefaultTheme
     <template #nav-bar-content-after>
       <VersionSwitcher />
     </template>
+    <template #nav-screen-content-after>
+      <VersionSwitcher class="vp-nav-screen-version-switcher" />
+    </template>
     <template #home-hero-before>
       <section class="fh">
         <!-- ── Animated background ───────────────────── -->

--- a/docs/.vitepress/theme/custom.css
+++ b/docs/.vitepress/theme/custom.css
@@ -685,3 +685,19 @@
     display: none;
   }
 }
+
+/* VersionSwitcher in the mobile screen menu */
+.vp-nav-screen-version-switcher {
+  display: none;
+}
+
+@media (max-width: 768px) {
+  .vp-nav-screen-version-switcher {
+    display: inline-flex;
+    width: 100%;
+    margin-left: 0;
+    margin-top: 12px;
+    height: 40px;
+    font-size: 0.9rem;
+  }
+}


### PR DESCRIPTION
## Type of change
- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Proposal implementation

## Description

## Related issue

## Breaking changes?

## Tests added?
